### PR TITLE
Metal and dielectrics

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,9 @@ model {
                 def mult = project.getProperty('RES_MULT')
                 cppCompiler.args "-DRES_MULT=${mult}"
             }
+            if(project.hasProperty('NO_PROGRESS')) {
+                cppCompiler.args "-DNO_PROGRESS"
+            }
             cppCompiler.args "-std=c++11", "-msse4", "-fPIC", "-Wall"
             if (buildType == buildTypes.debug) {
                 cppCompiler.args "-g"

--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,14 @@ model {
     binaries {
         all {
             linker.args "-lncurses"
+            if(project.hasProperty('SAMPLES')) {
+                def samples = project.getProperty('SAMPLES')
+                cppCompiler.args "-DSAMPLES=${samples}"
+            }
+            if(project.hasProperty('RES_MULT')) {
+                def mult = project.getProperty('RES_MULT')
+                cppCompiler.args "-DRES_MULT=${mult}"
+            }
             cppCompiler.args "-std=c++11", "-msse4", "-fPIC", "-Wall"
             if (buildType == buildTypes.debug) {
                 cppCompiler.args "-g"

--- a/src/raymath/cpp/sphere.cpp
+++ b/src/raymath/cpp/sphere.cpp
@@ -34,7 +34,7 @@ void sphere::intersects(ray r, intersection& record) {
             record.hit      = true;
             record.distance = t;
             record.position = r.pointAt(t);
-            record.normal   = (record.position - center).normalized();
+            record.normal   = (record.position - center) / radius;
             return;
         }
     }

--- a/src/raymath/cpp/sphere.cpp
+++ b/src/raymath/cpp/sphere.cpp
@@ -1,4 +1,5 @@
 #include "sphere.h"
+#include <cstdio>
 #include "color.h"
 #include "intersection.h"
 
@@ -21,8 +22,12 @@ void sphere::intersects(ray r, intersection& record) {
         scalar sqrt_discrim = sqrt(discriminant);
         scalar inv_denom    = 1 / a;
         scalar t            = (-b - sqrt_discrim) * inv_denom;
-        if (t <= MIN_CONTACT) {
-            t = (-b + sqrt_discrim) * inv_denom;
+        bool dropped        = false;
+        scalar ot;
+        if (t < MIN_CONTACT) {
+            ot      = t;
+            t       = (-b + sqrt_discrim) * inv_denom;
+            dropped = true;
         }
         if (t > MIN_CONTACT) {
             // FIXME: in the future, this could be put into a lambda (which captures r, center and
@@ -34,6 +39,10 @@ void sphere::intersects(ray r, intersection& record) {
             record.distance = t;
             record.position = r.pointAt(t);
             record.normal   = (record.position - center) / radius;
+
+            if (dropped) {
+                fprintf(stderr, "dropped with t = %lf, old t = %lf\n", t, ot);
+            }
             return;
         }
     }

--- a/src/raymath/cpp/sphere.cpp
+++ b/src/raymath/cpp/sphere.cpp
@@ -12,15 +12,15 @@ void sphere::intersects(ray r, intersection& record) {
     scalar a = r.direction().dot(r.direction());
     vector i = r.origin() - center;
     // scalar b = 2 * r.direction().dot(i);
-    scalar b = 2 * i.dot(r.direction());
+    scalar b = i.dot(r.direction());
     scalar c = i.dot(i) - radius * radius;
 
-    scalar discriminant = b * b - 4 * a * c;
+    scalar discriminant = b * b - a * c;
 
     if (discriminant >= 0) {
         // check both roots -- get smallest non-negative
         scalar sqrt_discrim = sqrt(discriminant);
-        scalar inv_denom    = 1 / (2 * a);
+        scalar inv_denom    = 1 / a;
         scalar t            = (-b - sqrt_discrim) * inv_denom;
         if (t < MIN_CONTACT) {
             t = (-b + sqrt_discrim) * inv_denom;

--- a/src/raymath/cpp/sphere.cpp
+++ b/src/raymath/cpp/sphere.cpp
@@ -20,11 +20,11 @@ void sphere::intersects(ray r, intersection& record) {
     if (discriminant >= 0) {
         // check both roots -- get smallest non-negative
         scalar sqrt_discrim = sqrt(discriminant);
-        scalar t            = -b - sqrt_discrim;
-        if (t < MIN_CONTACT) {
-            t = -b + sqrt_discrim;
+        scalar inv_denom    = 1 / (2 * a);
+        scalar t            = (-b - sqrt_discrim) * inv_denom;
+        if (t < -MIN_CONTACT) {
+            t = (-b + sqrt_discrim) * inv_denom;
         }
-        t /= (2.0 * a);
         if (t > MIN_CONTACT) {
             // FIXME: in the future, this could be put into a lambda (which captures r, center and
             // texcoord stuff), and only evaluated once the caller used t to determine which

--- a/src/raymath/cpp/sphere.cpp
+++ b/src/raymath/cpp/sphere.cpp
@@ -11,7 +11,8 @@ void sphere::intersects(ray r, intersection& record) {
 
     scalar a = r.direction().dot(r.direction());
     vector i = r.origin() - center;
-    scalar b = 2 * r.direction().dot(i);
+    // scalar b = 2 * r.direction().dot(i);
+    scalar b = 2 * i.dot(r.direction());
     scalar c = i.dot(i) - radius * radius;
 
     scalar discriminant = b * b - 4 * a * c;

--- a/src/raymath/cpp/sphere.cpp
+++ b/src/raymath/cpp/sphere.cpp
@@ -11,18 +11,17 @@ void sphere::intersects(ray r, intersection& record) {
 
     scalar a = r.direction().dot(r.direction());
     vector i = r.origin() - center;
-    // scalar b = 2 * r.direction().dot(i);
     scalar b = i.dot(r.direction());
     scalar c = i.dot(i) - radius * radius;
 
     scalar discriminant = b * b - a * c;
 
-    if (discriminant >= 0) {
+    if (discriminant > 0) {
         // check both roots -- get smallest non-negative
         scalar sqrt_discrim = sqrt(discriminant);
         scalar inv_denom    = 1 / a;
         scalar t            = (-b - sqrt_discrim) * inv_denom;
-        if (t < MIN_CONTACT) {
+        if (t <= MIN_CONTACT) {
             t = (-b + sqrt_discrim) * inv_denom;
         }
         if (t > MIN_CONTACT) {

--- a/src/raymath/cpp/sphere.cpp
+++ b/src/raymath/cpp/sphere.cpp
@@ -17,7 +17,13 @@ void sphere::intersects(ray r, intersection& record) {
     scalar discriminant = b * b - 4 * a * c;
 
     if (discriminant >= 0) {
-        scalar t = (-b - sqrt(discriminant)) / (2.0 * a);
+        // check both roots -- get smallest non-negative
+        scalar sqrt_discrim = sqrt(discriminant);
+        scalar t            = -b - sqrt_discrim;
+        if (t < MIN_CONTACT) {
+            t = -b + sqrt_discrim;
+        }
+        t /= (2.0 * a);
         if (t > MIN_CONTACT) {
             // FIXME: in the future, this could be put into a lambda (which captures r, center and
             // texcoord stuff), and only evaluated once the caller used t to determine which

--- a/src/raymath/cpp/sphere.cpp
+++ b/src/raymath/cpp/sphere.cpp
@@ -41,7 +41,7 @@ void sphere::intersects(ray r, intersection& record) {
             record.normal   = (record.position - center) / radius;
 
             if (dropped) {
-                fprintf(stderr, "dropped with t = %lf, old t = %lf\n", t, ot);
+                // fprintf(stderr, "dropped with t = %lf, old t = %lf\n", t, ot);
             }
             return;
         }

--- a/src/raymath/cpp/sphere.cpp
+++ b/src/raymath/cpp/sphere.cpp
@@ -35,4 +35,4 @@ void sphere::intersects(ray r, intersection& record) {
     record.hit = false;
 }
 
-texcoord sphere::compute_texcoord(const intersection& record) { return texcoord(0,0); }
+texcoord sphere::compute_texcoord(const intersection& record) { return texcoord(0, 0); }

--- a/src/raymath/cpp/sphere.cpp
+++ b/src/raymath/cpp/sphere.cpp
@@ -22,7 +22,7 @@ void sphere::intersects(ray r, intersection& record) {
         scalar sqrt_discrim = sqrt(discriminant);
         scalar inv_denom    = 1 / (2 * a);
         scalar t            = (-b - sqrt_discrim) * inv_denom;
-        if (t < -MIN_CONTACT) {
+        if (t < MIN_CONTACT) {
             t = (-b + sqrt_discrim) * inv_denom;
         }
         if (t > MIN_CONTACT) {

--- a/src/raymath/headers/geometry.h
+++ b/src/raymath/headers/geometry.h
@@ -1,18 +1,18 @@
 #ifndef _RAYMATH_GEOMETRY_H_
 #define _RAYMATH_GEOMETRY_H_
+#include <list>
+#include <memory>
 #include "Eigen/Dense"
 #include "color.h"
 #include "intersection.h"
 #include "types.h"
-#include <list>
-#include <memory>
 
 // geometry describes a geometric object, that is both intersectable and texturable.
 // This means it can both interact with the 3D world (intersect),
 // and itself in 2D (texture).
 struct geometry {
-    virtual texcoord compute_texcoord(const intersection& record)                  = 0;
-    virtual void intersects(ray r, intersection& record) = 0;
+    virtual texcoord compute_texcoord(const intersection& record) = 0;
+    virtual void intersects(ray r, intersection& record)          = 0;
 
     intersection intersects(ray r) {
         intersection hit;
@@ -20,7 +20,6 @@ struct geometry {
         return hit;
     }
 };
-
 
 typedef std::list<std::unique_ptr<geometry>> geometry_list;
 

--- a/src/raymath/headers/intersection.h
+++ b/src/raymath/headers/intersection.h
@@ -12,7 +12,7 @@ struct intersection {
 
     intersection() : hit(false), id(-1){};
     intersection(long id, vector position, vector normal, scalar distance)
-        : hit(true), id(id), position(position), normal(normal), distance(distance) {};
+        : hit(true), id(id), position(position), normal(normal), distance(distance){};
     operator bool() const { return hit; };
     bool operator!() const { return !hit; };
 };

--- a/src/raymath/test/intersection_tests.cpp
+++ b/src/raymath/test/intersection_tests.cpp
@@ -49,6 +49,7 @@ TEST(Intersection, SphereRayIntersectionPosition) {
 
     hit      = sphere(vector(0, 0, 0), 2).intersects(ray(vector(0, 0, -3), vector(0, 0, 1)));
     expected = vector(0, 0, -2);
+    EXPECT_TRUE(hit);
     EXPECT_TRUE(hit.position.isApprox(expected, 0.0001))
         << "  Actual: "
         << "{" << hit.position[0] << ", " << hit.position[1] << ", " << hit.position[2] << "}"
@@ -57,6 +58,7 @@ TEST(Intersection, SphereRayIntersectionPosition) {
 
     hit      = sphere(vector(0, 3, 0), 2).intersects(ray(vector(0, 0, -3), vector(0, 1, 0.5)));
     expected = vector(0, 2.27335, -1.863325);
+    EXPECT_TRUE(hit);
     EXPECT_TRUE(hit.position.isApprox(expected, 0.0001))
         << "  Actual: "
         << "{" << hit.position[0] << ", " << hit.position[1] << ", " << hit.position[2] << "}"
@@ -70,6 +72,7 @@ TEST(Intersection, SphereRayIntersectionNormal) {
 
     hit      = sphere(vector(0, 0, 0), 2).intersects(ray(vector(0, 0, -3), vector(0, 0, 1)));
     expected = vector(0, 0, -1);
+    EXPECT_TRUE(hit);
     EXPECT_TRUE(hit.normal.isApprox(expected, 0.0001))
         << "  Actual: "
         << "{" << hit.normal[0] << ", " << hit.normal[1] << ", " << hit.normal[2] << "}"
@@ -78,6 +81,7 @@ TEST(Intersection, SphereRayIntersectionNormal) {
 
     hit      = sphere(vector(0, 3, 0), 2).intersects(ray(vector(0, 0, -3), vector(0, 1, 0.5)));
     expected = vector(0, -0.363325, -0.931662);
+    EXPECT_TRUE(hit);
     EXPECT_TRUE(hit.normal.isApprox(expected, 0.0001))
         << "  Actual: "
         << "{" << hit.normal[0] << ", " << hit.normal[1] << ", " << hit.normal[2] << "}"

--- a/src/raymath/test/intersection_tests.cpp
+++ b/src/raymath/test/intersection_tests.cpp
@@ -126,3 +126,26 @@ TEST(Intersection, SphereRayIntersectionInternal) {
         << "{" << expected_normal[0] << ", " << expected_normal[1] << ", " << expected_normal[2]
         << "}";
 }
+
+TEST(Intersection, SphereRayIntersectionNormalNegativeRadius) {
+    intersection hit;
+    vector expected;
+
+    hit      = sphere(vector(0, 0, 0), -2).intersects(ray(vector(0, 0, -3), vector(0, 0, 1)));
+    expected = vector(0, 0, 1);
+    EXPECT_TRUE(hit);
+    EXPECT_TRUE(hit.normal.isApprox(expected, 0.0001))
+        << "  Actual: "
+        << "{" << hit.normal[0] << ", " << hit.normal[1] << ", " << hit.normal[2] << "}"
+        << "\nExpected: "
+        << "{" << expected[0] << ", " << expected[1] << ", " << expected[2] << "}";
+
+    hit      = sphere(vector(0, 3, 0), -2).intersects(ray(vector(0, 0, -3), vector(0, 1, 0.5)));
+    expected = vector(0, 0.363325, 0.931662);
+    EXPECT_TRUE(hit);
+    EXPECT_TRUE(hit.normal.isApprox(expected, 0.0001))
+        << "  Actual: "
+        << "{" << hit.normal[0] << ", " << hit.normal[1] << ", " << hit.normal[2] << "}"
+        << "\nExpected: "
+        << "{" << expected[0] << ", " << expected[1] << ", " << expected[2] << "}";
+}

--- a/src/raymath/test/intersection_tests.cpp
+++ b/src/raymath/test/intersection_tests.cpp
@@ -33,6 +33,16 @@ TEST(Intersection, BoolEvaluation) {
     }
 }
 
+TEST(Intersection, SphereRayIntersectionBehind) {
+    intersection hit;
+
+    hit = sphere(vector(0, 0, 0), 2).intersects(ray(vector(0, 0, -3), vector(0, 0, -1)));
+    EXPECT_FALSE(hit);
+
+    hit = sphere(vector(0, 3, 0), 2).intersects(ray(vector(0, 0, -3), vector(0, -1, -0.5)));
+    EXPECT_FALSE(hit);
+}
+
 TEST(Intersection, SphereRayIntersectionPosition) {
     intersection hit;
     vector expected;

--- a/src/raymath/test/intersection_tests.cpp
+++ b/src/raymath/test/intersection_tests.cpp
@@ -88,3 +88,41 @@ TEST(Intersection, SphereRayIntersectionNormal) {
         << "\nExpected: "
         << "{" << expected[0] << ", " << expected[1] << ", " << expected[2] << "}";
 }
+
+TEST(Intersection, SphereRayIntersectionInternal) {
+    intersection hit;
+
+    hit = sphere(vector(0, 0, 0), 2).intersects(ray(vector(0, 0, 1), vector(0, 0, 1)));
+    vector expected_normal   = vector(0, 0, 1);
+    vector expected_position = vector(0, 0, 2);
+    EXPECT_TRUE(hit);
+    EXPECT_TRUE(hit.position.isApprox(expected_position, 0.0001))
+        << "  Actual: "
+        << "{" << hit.position[0] << ", " << hit.position[1] << ", " << hit.position[2] << "}"
+        << "\nExpected: "
+        << "{" << expected_position[0] << ", " << expected_position[1] << ", "
+        << expected_position[2] << "}";
+    EXPECT_TRUE(hit.normal.isApprox(expected_normal, 0.0001))
+        << "  Actual: "
+        << "{" << hit.normal[0] << ", " << hit.normal[1] << ", " << hit.normal[2] << "}"
+        << "\nExpected: "
+        << "{" << expected_normal[0] << ", " << expected_normal[1] << ", " << expected_normal[2]
+        << "}";
+
+    hit = sphere(vector(0, 3, 0), 2).intersects(ray(vector(0, 3, 1), vector(0, 1, 1.5)));
+    expected_normal   = vector(0, 0.302169, 0.953254);
+    expected_position = vector(0, 3.604339, 1.906508);
+    EXPECT_TRUE(hit);
+    EXPECT_TRUE(hit.position.isApprox(expected_position, 0.0001))
+        << "  Actual: "
+        << "{" << hit.position[0] << ", " << hit.position[1] << ", " << hit.position[2] << "}"
+        << "\nExpected: "
+        << "{" << expected_position[0] << ", " << expected_position[1] << ", "
+        << expected_position[2] << "}";
+    EXPECT_TRUE(hit.normal.isApprox(expected_normal, 0.0001))
+        << "  Actual: "
+        << "{" << hit.normal[0] << ", " << hit.normal[1] << ", " << hit.normal[2] << "}"
+        << "\nExpected: "
+        << "{" << expected_normal[0] << ", " << expected_normal[1] << ", " << expected_normal[2]
+        << "}";
+}

--- a/src/raytrace/cpp/material.cpp
+++ b/src/raytrace/cpp/material.cpp
@@ -4,7 +4,16 @@ vector reflect(const vector& in, const vector& normal) {
     return vector(in - 2 * in.dot(normal) * normal);
 }
 
-vector refract(const vector& in, const vector& normal) { return vector(0, 0, 0); }
+bool refract(const vector& in, const vector& normal, scalar ni_div_nt, vector& refracted) {
+    vector norm_in = in.normalized();
+    scalar dt      = norm_in.dot(normal);
+    scalar discrim = 1.0 - ni_div_nt * ni_div_nt * (1 - dt * dt);
+    if (discrim > 0) {
+        refracted = ni_div_nt * (norm_in - normal * dt) - normal * sqrt(discrim);
+        return true;
+    }
+    return false;
+}
 
 bool Lambertian::scatter(
     const ray& incoming, ray& outgoing, const intersection& hit, color& attenuation) const {

--- a/src/raytrace/cpp/material.cpp
+++ b/src/raytrace/cpp/material.cpp
@@ -15,6 +15,12 @@ bool refract(const vector& in, const vector& normal, scalar ni_div_nt, vector& r
     return false;
 }
 
+scalar schlick(scalar cos, scalar refrac_index) {
+    scalar r0 = (1 - refrac_index) / (1 + refrac_index);
+    r0 *= r0;
+    return r0 + (1 - r0) * pow((1 - cos), 5);
+}
+
 bool Lambertian::scatter(
     const ray& incoming, ray& outgoing, const intersection& hit, color& attenuation) const {
     vector bounce(hit.position + hit.normal + random_in_usphere());

--- a/src/raytrace/cpp/material.cpp
+++ b/src/raytrace/cpp/material.cpp
@@ -1,8 +1,27 @@
 #include "material.h"
 
-bool Lambertian::scatter(const ray& incoming, ray& outgoing, const intersection& hit, color& attenuation) {
+vector reflect(const vector& in, const vector& normal) {
+    return vector(in - 2 * in.dot(normal) * normal);
+}
+
+vector refract(const vector& in, const vector& normal) {
+    return vector(0, 0, 0);
+}
+
+bool Lambertian::scatter(const ray& incoming, ray& outgoing, const intersection& hit, color& attenuation) const {
     vector bounce(hit.position + hit.normal + random_in_usphere());
     outgoing = ray(hit.position, bounce - hit.position);
     attenuation = albedo;
     return true;
+}
+
+bool Metal::scatter(const ray& incoming, ray& outgoing, const intersection& hit, color& attenuation) const {
+    vector reflected = reflect(incoming.direction(), hit.normal);
+    outgoing = ray(hit.position, reflected + roughness*random_in_usphere());
+    attenuation = albedo;
+    return reflected.dot(hit.normal) > 0;
+}
+
+bool Dielectric::scatter(const ray& incoming, ray& outgoing, const intersection& hit, color& attenuation) const {
+    return false;
 }

--- a/src/raytrace/cpp/material.cpp
+++ b/src/raytrace/cpp/material.cpp
@@ -4,24 +4,25 @@ vector reflect(const vector& in, const vector& normal) {
     return vector(in - 2 * in.dot(normal) * normal);
 }
 
-vector refract(const vector& in, const vector& normal) {
-    return vector(0, 0, 0);
-}
+vector refract(const vector& in, const vector& normal) { return vector(0, 0, 0); }
 
-bool Lambertian::scatter(const ray& incoming, ray& outgoing, const intersection& hit, color& attenuation) const {
+bool Lambertian::scatter(
+    const ray& incoming, ray& outgoing, const intersection& hit, color& attenuation) const {
     vector bounce(hit.position + hit.normal + random_in_usphere());
-    outgoing = ray(hit.position, bounce - hit.position);
+    outgoing    = ray(hit.position, bounce - hit.position);
     attenuation = albedo;
     return true;
 }
 
-bool Metal::scatter(const ray& incoming, ray& outgoing, const intersection& hit, color& attenuation) const {
+bool Metal::scatter(
+    const ray& incoming, ray& outgoing, const intersection& hit, color& attenuation) const {
     vector reflected = reflect(incoming.direction(), hit.normal);
-    outgoing = ray(hit.position, reflected + roughness*random_in_usphere());
-    attenuation = albedo;
+    outgoing         = ray(hit.position, reflected + roughness * random_in_usphere());
+    attenuation      = albedo;
     return reflected.dot(hit.normal) > 0;
 }
 
-bool Dielectric::scatter(const ray& incoming, ray& outgoing, const intersection& hit, color& attenuation) const {
+bool Dielectric::scatter(
+    const ray& incoming, ray& outgoing, const intersection& hit, color& attenuation) const {
     return false;
 }

--- a/src/raytrace/cpp/material.cpp
+++ b/src/raytrace/cpp/material.cpp
@@ -33,5 +33,24 @@ bool Metal::scatter(
 
 bool Dielectric::scatter(
     const ray& incoming, ray& outgoing, const intersection& hit, color& attenuation) const {
-    return false;
+    vector out_normal;
+    vector reflected = reflect(incoming.direction(), hit.normal);
+    scalar ni_div_nt;
+    attenuation = albedo;
+    vector refracted;
+    if (incoming.direction().dot(hit.normal) > 0) {
+        out_normal = -hit.normal;
+        ni_div_nt  = refrac_index;
+    } else {
+        out_normal = hit.normal;
+        ni_div_nt  = 1.0 / refrac_index;
+    }
+
+    if (refract(incoming.direction(), out_normal, ni_div_nt, refracted)) {
+        outgoing = ray(hit.position, refracted);
+    } else {
+        outgoing = ray(hit.position, reflected);
+        return false;
+    }
+    return true;
 }

--- a/src/raytrace/cpp/raytracer.cpp
+++ b/src/raytrace/cpp/raytracer.cpp
@@ -34,18 +34,18 @@ int raytrace_ppm(const char* filename, progress_callback cb /* = NULL */) {
     Material* diffuse = new Metal(color(0.3, 0.5, 0.8), 1);
 
     // geometric shape declarations
-    geometry* ground_sphere = new sphere(vector(0, -100.5, -1), 100);
-    geometry* sphere1       = new sphere(vector(0, 0, -3), 1.0);
+    geometry* ground_sphere = new sphere(vector(0, -401, -2), 400);
+    geometry* sphere1       = new sphere(vector(0, 0, -2), 1.0);
     geometry* sphere2       = new sphere(vector(1.8, -0.25, -3), 0.75);
     geometry* sphere3       = new sphere(vector(-2.75, 0.25, -3), 1.5);
     geometry* metal4        = new sphere(vector(-0.5, -0.6, -1.75), 0.4);
     geometry* mirror5       = new sphere(vector(104, 0, -3), 100);
     geometry* diffuse6      = new sphere(vector(-1, 2, -12), 6);
 
-    geometry* sphere7  = new sphere(vector(0, 0, -1), 0.5);
-    geometry* sphere8  = new sphere(vector(0, 0, -1), 0.5);
-    geometry* sphere9  = new sphere(vector(-1, 0, -1), 0.5);
-    geometry* sphere10 = new sphere(vector(-1, 0, -1), -0.45);
+    geometry* sphere7  = new sphere(vector(1, 0, -1.25), 0.5);
+    geometry* sphere8  = new sphere(vector(0, 0, -1.25), 0.5);
+    geometry* sphere9  = new sphere(vector(-1, 0, -1.25), 0.5);
+    geometry* sphere10 = new sphere(vector(-1, 0, -1.25), -0.45);
 
     // refractive scene tests
     // geometry* sphere7 = new sphere(vector(0.75, 0, -1.5), 0.5);
@@ -61,10 +61,11 @@ int raytrace_ppm(const char* filename, progress_callback cb /* = NULL */) {
     // w.add_object(new WorldObject(5, mirror, &w, mirror5));
     // w.add_object(new WorldObject(6, diffuse, &w, diffuse6));
 
-    w.add_object(new WorldObject(7, new Metal(color(0.8, 0.6, 0.2), 0.6), &w, sphere7));
+    // w.add_object(new WorldObject(7, new Metal(color(0.8, 0.6, 0.2), 0.6), &w, sphere1));
     // w.add_object(new WorldObject(8, new Lambertian(color(0.1, 0.2, 0.5)), &w, sphere8));
     // w.add_object(new WorldObject(9, new Dielectric(1.5), &w, sphere9));
     // w.add_object(new WorldObject(10, new Dielectric(1.5), &w, sphere10));
+    w.add_object(new WorldObject(10, new Dielectric(1.5), &w, sphere1));
 
     Camera* cam = new Camera(width, height, 90);
 

--- a/src/raytrace/cpp/raytracer.cpp
+++ b/src/raytrace/cpp/raytracer.cpp
@@ -45,7 +45,7 @@ int raytrace_ppm(const char* filename, progress_callback cb /* = NULL */) {
     geometry* sphere7  = new sphere(vector(1, 0, -1), 0.5);
     geometry* sphere8  = new sphere(vector(0, 0, -1), 0.5);
     geometry* sphere9  = new sphere(vector(-1, 0, -1), 0.5);
-    geometry* sphere10 = new sphere(vector(-1, 0, -1), -0.4);
+    geometry* sphere10 = new sphere(vector(-1, 0, -1), -0.475);
 
     // geometry* sphere7 = new sphere(vector(0.75, 0, -1.5), 0.5);
     // geometry* sphere8 = new sphere(vector(-0.75, 0, -1.5), 0.5);
@@ -60,8 +60,7 @@ int raytrace_ppm(const char* filename, progress_callback cb /* = NULL */) {
     // w.add_object(new WorldObject(5, mirror, &w, mirror5));
     // w.add_object(new WorldObject(6, diffuse, &w, diffuse6));
 
-    // w.add_object(new WorldObject(7, new Metal(color(0.8, 0.6, 0.2), 0.6), &w, sphere7));
-    w.add_object(new WorldObject(7, new Metal(color(0.65, 0.65, 0.7), 0.02), &w, sphere7));
+    w.add_object(new WorldObject(7, new Metal(color(0.8, 0.6, 0.2), 0.6), &w, sphere7));
     w.add_object(new WorldObject(8, new Lambertian(color(0.1, 0.2, 0.5)), &w, sphere8));
     w.add_object(new WorldObject(9, new Dielectric(1.5), &w, sphere9));
     w.add_object(new WorldObject(10, new Dielectric(1.5), &w, sphere10));

--- a/src/raytrace/cpp/raytracer.cpp
+++ b/src/raytrace/cpp/raytracer.cpp
@@ -29,18 +29,27 @@ int raytrace_ppm(const char* filename, progress_callback cb /* = NULL */) {
     Material* green = new Lambertian(color(0, 1, 0));
     Material* blue = new Lambertian(color(0, 0, 1));
     Material* ground = new Lambertian(color(0.3, 0.25, 0.4));
+    Material* metal = new Metal(color(0.6, 0.2, 0.3), 0.1);
+    Material* mirror = new Metal(color(0.25, 0.25, 0.25), 0.02);
+    Material* diffuse = new Metal(color(0.3, 0.5, 0.8), 1);
 
     // geometric shape declarations
     geometry* ground_sphere = new sphere(vector(0, -301, -3), 300);
     geometry* sphere1 = new sphere(vector(0, 0, -3), 1.0);
     geometry* sphere2 = new sphere(vector(1.8, -0.25, -3), 0.75);
     geometry* sphere3 = new sphere(vector(-2.75, 0.25, -3), 1.5);
+    geometry* metal4 = new sphere(vector(-0.5, -0.6, -1.75), 0.4);
+    geometry* mirror5 = new sphere(vector(104, 0, -3), 100);
+    geometry* diffuse6 = new sphere(vector(-1, 2, -12), 6);
 
     // world object addition and creation
     w.add_object(new WorldObject(0, ground, &w, ground_sphere));
     w.add_object(new WorldObject(1, red, &w, sphere1));
     w.add_object(new WorldObject(2, green, &w, sphere2));
     w.add_object(new WorldObject(3, blue, &w, sphere3));
+    w.add_object(new WorldObject(4, metal, &w, metal4));
+    w.add_object(new WorldObject(5, mirror, &w, mirror5));
+    w.add_object(new WorldObject(6, diffuse, &w, diffuse6));
 
     Camera* cam = new Camera(width, height, 78);
 

--- a/src/raytrace/cpp/raytracer.cpp
+++ b/src/raytrace/cpp/raytracer.cpp
@@ -42,9 +42,14 @@ int raytrace_ppm(const char* filename, progress_callback cb /* = NULL */) {
     // geometry* mirror5       = new sphere(vector(104, 0, -3), 100);
     // geometry* diffuse6      = new sphere(vector(-1, 2, -12), 6);
 
-    geometry* sphere7 = new sphere(vector(1, 0, -1), 0.5);
-    geometry* sphere8 = new sphere(vector(0, 0, -1), 0.5);
-    geometry* sphere9 = new sphere(vector(-1, 0, -1), 0.5);
+    geometry* sphere7  = new sphere(vector(1, 0, -1), 0.5);
+    geometry* sphere8  = new sphere(vector(0, 0, -1), 0.5);
+    geometry* sphere9  = new sphere(vector(-1, 0, -1), 0.5);
+    geometry* sphere10 = new sphere(vector(-1, 0, -1), -0.4);
+
+    // geometry* sphere7 = new sphere(vector(0.75, 0, -1.5), 0.5);
+    // geometry* sphere8 = new sphere(vector(-0.75, 0, -1.5), 0.5);
+    // geometry* sphere9 = new sphere(vector(0, 0, -0.8), 0.5);
 
     // // world object addition and creation
     w.add_object(new WorldObject(0, ground, &w, ground_sphere));
@@ -55,9 +60,11 @@ int raytrace_ppm(const char* filename, progress_callback cb /* = NULL */) {
     // w.add_object(new WorldObject(5, mirror, &w, mirror5));
     // w.add_object(new WorldObject(6, diffuse, &w, diffuse6));
 
-    w.add_object(new WorldObject(7, new Metal(color(0.8, 0.6, 0.2), 1.0), &w, sphere7));
+    // w.add_object(new WorldObject(7, new Metal(color(0.8, 0.6, 0.2), 0.6), &w, sphere7));
+    w.add_object(new WorldObject(7, new Metal(color(0.65, 0.65, 0.7), 0.02), &w, sphere7));
     w.add_object(new WorldObject(8, new Lambertian(color(0.1, 0.2, 0.5)), &w, sphere8));
     w.add_object(new WorldObject(9, new Dielectric(1.5), &w, sphere9));
+    w.add_object(new WorldObject(10, new Dielectric(1.5), &w, sphere10));
 
     Camera* cam = new Camera(width, height, 90);
 

--- a/src/raytrace/cpp/raytracer.cpp
+++ b/src/raytrace/cpp/raytracer.cpp
@@ -19,28 +19,28 @@ int raytrace_ppm(const char* filename, progress_callback cb /* = NULL */) {
         return 1;
     }
 
-    int width = int(80 * RES_MULT);
+    int width  = int(80 * RES_MULT);
     int height = int(52 * RES_MULT);
 
     World w;
 
     // diffuse material declarations
-    Material* red = new Lambertian(color(1, 0, 0));
-    Material* green = new Lambertian(color(0, 1, 0));
-    Material* blue = new Lambertian(color(0, 0, 1));
-    Material* ground = new Lambertian(color(0.3, 0.25, 0.4));
-    Material* metal = new Metal(color(0.6, 0.2, 0.3), 0.1);
-    Material* mirror = new Metal(color(0.25, 0.25, 0.25), 0.02);
+    Material* red     = new Lambertian(color(1, 0, 0));
+    Material* green   = new Lambertian(color(0, 1, 0));
+    Material* blue    = new Lambertian(color(0, 0, 1));
+    Material* ground  = new Lambertian(color(0.3, 0.25, 0.4));
+    Material* metal   = new Metal(color(0.6, 0.2, 0.3), 0.1);
+    Material* mirror  = new Metal(color(0.25, 0.25, 0.25), 0.02);
     Material* diffuse = new Metal(color(0.3, 0.5, 0.8), 1);
 
     // geometric shape declarations
     geometry* ground_sphere = new sphere(vector(0, -301, -3), 300);
-    geometry* sphere1 = new sphere(vector(0, 0, -3), 1.0);
-    geometry* sphere2 = new sphere(vector(1.8, -0.25, -3), 0.75);
-    geometry* sphere3 = new sphere(vector(-2.75, 0.25, -3), 1.5);
-    geometry* metal4 = new sphere(vector(-0.5, -0.6, -1.75), 0.4);
-    geometry* mirror5 = new sphere(vector(104, 0, -3), 100);
-    geometry* diffuse6 = new sphere(vector(-1, 2, -12), 6);
+    geometry* sphere1       = new sphere(vector(0, 0, -3), 1.0);
+    geometry* sphere2       = new sphere(vector(1.8, -0.25, -3), 0.75);
+    geometry* sphere3       = new sphere(vector(-2.75, 0.25, -3), 1.5);
+    geometry* metal4        = new sphere(vector(-0.5, -0.6, -1.75), 0.4);
+    geometry* mirror5       = new sphere(vector(104, 0, -3), 100);
+    geometry* diffuse6      = new sphere(vector(-1, 2, -12), 6);
 
     // world object addition and creation
     w.add_object(new WorldObject(0, ground, &w, ground_sphere));
@@ -56,7 +56,7 @@ int raytrace_ppm(const char* filename, progress_callback cb /* = NULL */) {
     fprintf(outfile, "P3\n%i %i\n255\n", width, height);
     intersection hit;
     float pixels = width * height;
-    int pixel = 0;
+    int pixel    = 0;
     for (int y = height - 1; y >= 0; y--) {
         for (int x = 0; x < width; x++) {
             color outcol(0, 0, 0);
@@ -72,7 +72,7 @@ int raytrace_ppm(const char* filename, progress_callback cb /* = NULL */) {
 
             colori col((outcol / SAMPLES).array().sqrt());
             fprintf(outfile, "%i %i %i\n", col.r, col.g, col.b);
-            if(cb != NULL) {
+            if (cb != NULL) {
                 cb(pixel++ / pixels);
             }
         }

--- a/src/raytrace/cpp/raytracer.cpp
+++ b/src/raytrace/cpp/raytracer.cpp
@@ -29,17 +29,18 @@ int raytrace_ppm(const char* filename, progress_callback cb /* = NULL */) {
     Material* green   = new Lambertian(color(0, 1, 0));
     Material* blue    = new Lambertian(color(0, 0, 1));
     Material* ground  = new Lambertian(color(0.8, 0.8, 0));
-    Material* metal   = new Metal(color(0.6, 0.2, 0.3), 0.1);
-    Material* mirror  = new Metal(color(0.25, 0.25, 0.25), 0.02);
-    Material* diffuse = new Metal(color(0.3, 0.5, 0.8), 1);
+    Material* metal   = new Metal(color(0.6, 0.2, 0.3), 0.2);
+    Material* mirror  = new Metal(color(0.85, 0.85, 0.7), 0);
+    Material* diffuse = new Metal(color(0.3, 0.5, 0.8), 0.75);
+    Material* glass   = new Dielectric(1.5);
 
     // geometric shape declarations
-    geometry* ground_sphere = new sphere(vector(0, -401, -2), 400);
-    geometry* sphere1       = new sphere(vector(0, 0, -2), 1.0);
-    geometry* sphere2       = new sphere(vector(1.8, -0.25, -3), 0.75);
+    geometry* ground_sphere = new sphere(vector(0, -1001, -2), 1000);
+    geometry* sphere1       = new sphere(vector(0, 0, -3), 1.0);
+    geometry* sphere2       = new sphere(vector(2.0, -0.25, -3), 0.75);
     geometry* sphere3       = new sphere(vector(-2.75, 0.25, -3), 1.5);
-    geometry* metal4        = new sphere(vector(-0.5, -0.6, -1.75), 0.4);
-    geometry* mirror5       = new sphere(vector(104, 0, -3), 100);
+    geometry* metal4        = new sphere(vector(-0.5, -0.5, -1.5), 0.5);
+    geometry* mirror5       = new sphere(vector(105, 0, -3), 100);
     geometry* diffuse6      = new sphere(vector(-1, 2, -12), 6);
 
     geometry* sphere7  = new sphere(vector(1, 0, -1.25), 0.5);
@@ -54,18 +55,18 @@ int raytrace_ppm(const char* filename, progress_callback cb /* = NULL */) {
 
     // // world object addition and creation
     w.add_object(new WorldObject(0, ground, &w, ground_sphere));
-    // w.add_object(new WorldObject(1, red, &w, sphere1));
-    // w.add_object(new WorldObject(2, green, &w, sphere2));
-    // w.add_object(new WorldObject(3, blue, &w, sphere3));
-    // w.add_object(new WorldObject(4, metal, &w, metal4));
-    // w.add_object(new WorldObject(5, mirror, &w, mirror5));
-    // w.add_object(new WorldObject(6, diffuse, &w, diffuse6));
+    w.add_object(new WorldObject(1, red, &w, sphere1));
+    w.add_object(new WorldObject(2, glass, &w, sphere2));
+    w.add_object(new WorldObject(3, mirror, &w, sphere3));
+    w.add_object(new WorldObject(4, metal, &w, metal4));
+    w.add_object(new WorldObject(5, diffuse, &w, mirror5));
+    w.add_object(new WorldObject(6, blue, &w, diffuse6));
 
     // w.add_object(new WorldObject(7, new Metal(color(0.8, 0.6, 0.2), 0.6), &w, sphere1));
     // w.add_object(new WorldObject(8, new Lambertian(color(0.1, 0.2, 0.5)), &w, sphere8));
     // w.add_object(new WorldObject(9, new Dielectric(1.5), &w, sphere9));
     // w.add_object(new WorldObject(10, new Dielectric(1.5), &w, sphere10));
-    w.add_object(new WorldObject(10, new Dielectric(1.5), &w, sphere1));
+    //w.add_object(new WorldObject(10, new Dielectric(1.5), &w, sphere1));
 
     Camera* cam = new Camera(width, height, 90);
 

--- a/src/raytrace/cpp/raytracer.cpp
+++ b/src/raytrace/cpp/raytracer.cpp
@@ -4,9 +4,13 @@
 #include "raymath"
 #include "world.h"
 
-#define MAX_DEPTH 32
-#define ABSORPTION 0.5
-#define SAMPLES_PER_PIXEL 32
+#ifndef SAMPLES
+#define SAMPLES 32
+#endif
+
+#ifndef RES_MULT
+#define RES_MULT 1.0
+#endif
 
 int raytrace_ppm(const char* filename, progress_callback cb /* = NULL */) {
     FILE* outfile = fopen(filename, "w");
@@ -15,10 +19,8 @@ int raytrace_ppm(const char* filename, progress_callback cb /* = NULL */) {
         return 1;
     }
 
-    int width  = 16 * 20;
-    int height = 9 * 20;
-    //int width = 80;
-    //int height = 52;
+    int width = int(80 * RES_MULT);
+    int height = int(52 * RES_MULT);
 
     World w;
 
@@ -49,7 +51,7 @@ int raytrace_ppm(const char* filename, progress_callback cb /* = NULL */) {
     for (int y = height - 1; y >= 0; y--) {
         for (int x = 0; x < width; x++) {
             color outcol(0, 0, 0);
-            for (int sample = 0; sample < SAMPLES_PER_PIXEL; sample++) {
+            for (int sample = 0; sample < SAMPLES; sample++) {
                 scalar u = 2 * ((scalar(x) + random_scalar()) / scalar(width)) - 1;
                 scalar v = 2 * ((scalar(y) + random_scalar()) / scalar(height)) - 1;
                 ray r    = cam->get_screen_ray(u, v);
@@ -59,7 +61,7 @@ int raytrace_ppm(const char* filename, progress_callback cb /* = NULL */) {
             // gamma correct outcol
             // raise to 1 / gamma (1/2 in our case)
 
-            colori col((outcol / SAMPLES_PER_PIXEL).array().sqrt());
+            colori col((outcol / SAMPLES).array().sqrt());
             fprintf(outfile, "%i %i %i\n", col.r, col.g, col.b);
             if(cb != NULL) {
                 cb(pixel++ / pixels);

--- a/src/raytrace/cpp/raytracer.cpp
+++ b/src/raytrace/cpp/raytracer.cpp
@@ -35,18 +35,19 @@ int raytrace_ppm(const char* filename, progress_callback cb /* = NULL */) {
 
     // geometric shape declarations
     geometry* ground_sphere = new sphere(vector(0, -100.5, -1), 100);
-    // geometry* sphere1       = new sphere(vector(0, 0, -3), 1.0);
-    // geometry* sphere2       = new sphere(vector(1.8, -0.25, -3), 0.75);
-    // geometry* sphere3       = new sphere(vector(-2.75, 0.25, -3), 1.5);
-    // geometry* metal4        = new sphere(vector(-0.5, -0.6, -1.75), 0.4);
-    // geometry* mirror5       = new sphere(vector(104, 0, -3), 100);
-    // geometry* diffuse6      = new sphere(vector(-1, 2, -12), 6);
+    geometry* sphere1       = new sphere(vector(0, 0, -3), 1.0);
+    geometry* sphere2       = new sphere(vector(1.8, -0.25, -3), 0.75);
+    geometry* sphere3       = new sphere(vector(-2.75, 0.25, -3), 1.5);
+    geometry* metal4        = new sphere(vector(-0.5, -0.6, -1.75), 0.4);
+    geometry* mirror5       = new sphere(vector(104, 0, -3), 100);
+    geometry* diffuse6      = new sphere(vector(-1, 2, -12), 6);
 
-    geometry* sphere7  = new sphere(vector(1, 0, -1), 0.5);
+    geometry* sphere7  = new sphere(vector(0, 0, -1), 0.5);
     geometry* sphere8  = new sphere(vector(0, 0, -1), 0.5);
     geometry* sphere9  = new sphere(vector(-1, 0, -1), 0.5);
     geometry* sphere10 = new sphere(vector(-1, 0, -1), -0.45);
 
+    // refractive scene tests
     // geometry* sphere7 = new sphere(vector(0.75, 0, -1.5), 0.5);
     // geometry* sphere8 = new sphere(vector(-0.75, 0, -1.5), 0.5);
     // geometry* sphere9 = new sphere(vector(0, 0, -0.8), 0.5);
@@ -61,9 +62,9 @@ int raytrace_ppm(const char* filename, progress_callback cb /* = NULL */) {
     // w.add_object(new WorldObject(6, diffuse, &w, diffuse6));
 
     w.add_object(new WorldObject(7, new Metal(color(0.8, 0.6, 0.2), 0.6), &w, sphere7));
-    w.add_object(new WorldObject(8, new Lambertian(color(0.1, 0.2, 0.5)), &w, sphere8));
-    w.add_object(new WorldObject(9, new Dielectric(1.5), &w, sphere9));
-    w.add_object(new WorldObject(10, new Dielectric(1.5), &w, sphere10));
+    // w.add_object(new WorldObject(8, new Lambertian(color(0.1, 0.2, 0.5)), &w, sphere8));
+    // w.add_object(new WorldObject(9, new Dielectric(1.5), &w, sphere9));
+    // w.add_object(new WorldObject(10, new Dielectric(1.5), &w, sphere10));
 
     Camera* cam = new Camera(width, height, 90);
 

--- a/src/raytrace/cpp/raytracer.cpp
+++ b/src/raytrace/cpp/raytracer.cpp
@@ -45,7 +45,7 @@ int raytrace_ppm(const char* filename, progress_callback cb /* = NULL */) {
     geometry* sphere7  = new sphere(vector(1, 0, -1), 0.5);
     geometry* sphere8  = new sphere(vector(0, 0, -1), 0.5);
     geometry* sphere9  = new sphere(vector(-1, 0, -1), 0.5);
-    geometry* sphere10 = new sphere(vector(-1, 0, -1), -0.475);
+    geometry* sphere10 = new sphere(vector(-1, 0, -1), -0.45);
 
     // geometry* sphere7 = new sphere(vector(0.75, 0, -1.5), 0.5);
     // geometry* sphere8 = new sphere(vector(-0.75, 0, -1.5), 0.5);

--- a/src/raytrace/cpp/raytracer.cpp
+++ b/src/raytrace/cpp/raytracer.cpp
@@ -28,30 +28,38 @@ int raytrace_ppm(const char* filename, progress_callback cb /* = NULL */) {
     Material* red     = new Lambertian(color(1, 0, 0));
     Material* green   = new Lambertian(color(0, 1, 0));
     Material* blue    = new Lambertian(color(0, 0, 1));
-    Material* ground  = new Lambertian(color(0.3, 0.25, 0.4));
+    Material* ground  = new Lambertian(color(0.8, 0.8, 0));
     Material* metal   = new Metal(color(0.6, 0.2, 0.3), 0.1);
     Material* mirror  = new Metal(color(0.25, 0.25, 0.25), 0.02);
     Material* diffuse = new Metal(color(0.3, 0.5, 0.8), 1);
 
     // geometric shape declarations
-    geometry* ground_sphere = new sphere(vector(0, -301, -3), 300);
-    geometry* sphere1       = new sphere(vector(0, 0, -3), 1.0);
-    geometry* sphere2       = new sphere(vector(1.8, -0.25, -3), 0.75);
-    geometry* sphere3       = new sphere(vector(-2.75, 0.25, -3), 1.5);
-    geometry* metal4        = new sphere(vector(-0.5, -0.6, -1.75), 0.4);
-    geometry* mirror5       = new sphere(vector(104, 0, -3), 100);
-    geometry* diffuse6      = new sphere(vector(-1, 2, -12), 6);
+    geometry* ground_sphere = new sphere(vector(0, -100.5, -1), 100);
+    // geometry* sphere1       = new sphere(vector(0, 0, -3), 1.0);
+    // geometry* sphere2       = new sphere(vector(1.8, -0.25, -3), 0.75);
+    // geometry* sphere3       = new sphere(vector(-2.75, 0.25, -3), 1.5);
+    // geometry* metal4        = new sphere(vector(-0.5, -0.6, -1.75), 0.4);
+    // geometry* mirror5       = new sphere(vector(104, 0, -3), 100);
+    // geometry* diffuse6      = new sphere(vector(-1, 2, -12), 6);
 
-    // world object addition and creation
+    geometry* sphere7 = new sphere(vector(1, 0, -1), 0.5);
+    geometry* sphere8 = new sphere(vector(0, 0, -1), 0.5);
+    geometry* sphere9 = new sphere(vector(-1, 0, -1), 0.5);
+
+    // // world object addition and creation
     w.add_object(new WorldObject(0, ground, &w, ground_sphere));
-    w.add_object(new WorldObject(1, red, &w, sphere1));
-    w.add_object(new WorldObject(2, green, &w, sphere2));
-    w.add_object(new WorldObject(3, blue, &w, sphere3));
-    w.add_object(new WorldObject(4, metal, &w, metal4));
-    w.add_object(new WorldObject(5, mirror, &w, mirror5));
-    w.add_object(new WorldObject(6, diffuse, &w, diffuse6));
+    // w.add_object(new WorldObject(1, red, &w, sphere1));
+    // w.add_object(new WorldObject(2, green, &w, sphere2));
+    // w.add_object(new WorldObject(3, blue, &w, sphere3));
+    // w.add_object(new WorldObject(4, metal, &w, metal4));
+    // w.add_object(new WorldObject(5, mirror, &w, mirror5));
+    // w.add_object(new WorldObject(6, diffuse, &w, diffuse6));
 
-    Camera* cam = new Camera(width, height, 78);
+    w.add_object(new WorldObject(7, new Metal(color(0.8, 0.6, 0.2), 1.0), &w, sphere7));
+    w.add_object(new WorldObject(8, new Lambertian(color(0.1, 0.2, 0.5)), &w, sphere8));
+    w.add_object(new WorldObject(9, new Dielectric(1.5), &w, sphere9));
+
+    Camera* cam = new Camera(width, height, 90);
 
     fprintf(outfile, "P3\n%i %i\n255\n", width, height);
     intersection hit;

--- a/src/raytrace/cpp/world.cpp
+++ b/src/raytrace/cpp/world.cpp
@@ -10,7 +10,7 @@ WorldObjectPtr* World::intersects(ray r, intersection& record) {
         if (hit && hit.distance < closest_t) {
             record    = hit;
             closest_t = record.distance;
-            obj_hit = &(*it);
+            obj_hit   = &(*it);
         }
     }
     return obj_hit;

--- a/src/raytrace/cpp/world.cpp
+++ b/src/raytrace/cpp/world.cpp
@@ -25,5 +25,5 @@ color World::trace(ray r, intersection& record, int depth) {
     }
 
     scalar yness = (r.direction().normalized().y() + 1) / 2;
-    return (1 - yness) * color(1, 1, 1) + yness * color(0.5, 0.7, 1);
+    return (1 - yness) * color(1, 1, 1) + yness * color(0.3, 0.5, 1);
 }

--- a/src/raytrace/cpp/world_object.cpp
+++ b/src/raytrace/cpp/world_object.cpp
@@ -19,9 +19,9 @@ void WorldObject::intersects(ray r, intersection& record) {
 // colorize colors the given ray as if it hit at the given intersection, with the given trace depth
 color WorldObject::colorize(ray r, intersection& record, int depth) {
     ray scattered;
-    color outcol(0, 0, 0);
+    color outcol(1, 1, 1);
     if (depth < world->max_depth && material->scatter(r, scattered, record, outcol)) {
         return outcol.cwiseProduct(world->trace(scattered, record, depth + 1));
     }
-    return outcol;
+    return color(0, 0, 0);
 }

--- a/src/raytrace/cpp/world_object.cpp
+++ b/src/raytrace/cpp/world_object.cpp
@@ -11,7 +11,7 @@ void WorldObject::intersects(ray r, intersection& record) {
             closest_t = record.distance;
         }
     }
-    if(record) {
+    if (record) {
         record.id = id;
     }
 }
@@ -20,7 +20,7 @@ void WorldObject::intersects(ray r, intersection& record) {
 color WorldObject::colorize(ray r, intersection& record, int depth) {
     ray scattered;
     color outcol(0, 0, 0);
-    if(depth < world->max_depth && material->scatter(r, scattered, record, outcol)) {
+    if (depth < world->max_depth && material->scatter(r, scattered, record, outcol)) {
         return outcol.cwiseProduct(world->trace(scattered, record, depth + 1));
     }
     return outcol;

--- a/src/raytrace/cpp/world_object.cpp
+++ b/src/raytrace/cpp/world_object.cpp
@@ -23,5 +23,5 @@ color WorldObject::colorize(ray r, intersection& record, int depth) {
     if (depth < world->max_depth && material->scatter(r, scattered, record, outcol)) {
         return outcol.cwiseProduct(world->trace(scattered, record, depth + 1));
     }
-    return color(0, 0, 0);
+    return outcol;
 }

--- a/src/raytrace/headers/camera.h
+++ b/src/raytrace/headers/camera.h
@@ -13,9 +13,9 @@ class Camera {
 
    public:
     Camera(int width, int height, scalar fov) : width(width), height(height), fov(fov) {
-        origin          = vector(0, 0, 0);
-        aspect_ratio    = scalar(width) / scalar(height);
-        fov_height_len  = tan((fov / 2 * M_PI / 180));
+        origin         = vector(0, 0, 0);
+        aspect_ratio   = scalar(width) / scalar(height);
+        fov_height_len = tan((fov / 2 * M_PI / 180));
     }
 
     // get the ray originating from the camera going through screen coordinate (u, v)

--- a/src/raytrace/headers/material.h
+++ b/src/raytrace/headers/material.h
@@ -8,31 +8,36 @@ class Material {
     // scatter modifies r as if it was scattered from a hit at intersection
     // If no scattering should be done, false is returned. Otherwise true
     // is returned.
-    virtual bool scatter(const ray& incoming, ray& outgoing, const intersection& hit, color& attenuation) const = 0;
+    virtual bool scatter(
+        const ray& incoming, ray& outgoing, const intersection& hit, color& attenuation) const = 0;
 };
 
 class Lambertian : public Material {
     color albedo;
+
    public:
     Lambertian(color albedo) : albedo(albedo){};
-    bool scatter(const ray& incoming, ray& outgoing, const intersection& hit, color& attenuation) const;
+    bool scatter(
+        const ray& incoming, ray& outgoing, const intersection& hit, color& attenuation) const;
 };
 
 class Metal : public Material {
-   color albedo;
-   scalar roughness;
+    color albedo;
+    scalar roughness;
 
    public:
-    Metal(color albedo, scalar roughness) : albedo(albedo), roughness(roughness) {};
-    bool scatter(const ray& incoming, ray& outgoing, const intersection& hit, color& attenuation) const;
+    Metal(color albedo, scalar roughness) : albedo(albedo), roughness(roughness){};
+    bool scatter(
+        const ray& incoming, ray& outgoing, const intersection& hit, color& attenuation) const;
 };
 
 class Dielectric : public Material {
-   color albedo;
+    color albedo;
 
    public:
-    Dielectric() : albedo(color(1, 1, 0)) {};
-    bool scatter(const ray& incoming, ray& outgoing, const intersection& hit, color& attenuation) const;
+    Dielectric() : albedo(color(1, 1, 0)){};
+    bool scatter(
+        const ray& incoming, ray& outgoing, const intersection& hit, color& attenuation) const;
 };
 
 #endif

--- a/src/raytrace/headers/material.h
+++ b/src/raytrace/headers/material.h
@@ -8,14 +8,31 @@ class Material {
     // scatter modifies r as if it was scattered from a hit at intersection
     // If no scattering should be done, false is returned. Otherwise true
     // is returned.
-    virtual bool scatter(const ray& incoming, ray& outgoing, const intersection& hit, color& attenuation) = 0;
+    virtual bool scatter(const ray& incoming, ray& outgoing, const intersection& hit, color& attenuation) const = 0;
 };
 
 class Lambertian : public Material {
     color albedo;
    public:
     Lambertian(color albedo) : albedo(albedo){};
-    bool scatter(const ray& incoming, ray& outgoing, const intersection& hit, color& attenuation);
+    bool scatter(const ray& incoming, ray& outgoing, const intersection& hit, color& attenuation) const;
+};
+
+class Metal : public Material {
+   color albedo;
+   scalar roughness;
+
+   public:
+    Metal(color albedo, scalar roughness) : albedo(albedo), roughness(roughness) {};
+    bool scatter(const ray& incoming, ray& outgoing, const intersection& hit, color& attenuation) const;
+};
+
+class Dielectric : public Material {
+   color albedo;
+
+   public:
+    Dielectric() : albedo(color(1, 1, 0)) {};
+    bool scatter(const ray& incoming, ray& outgoing, const intersection& hit, color& attenuation) const;
 };
 
 #endif

--- a/src/raytrace/headers/material.h
+++ b/src/raytrace/headers/material.h
@@ -33,9 +33,10 @@ class Metal : public Material {
 
 class Dielectric : public Material {
     color albedo;
+    scalar refrac_index;
 
    public:
-    Dielectric() : albedo(color(1, 1, 0)){};
+    Dielectric(scalar refrac_index) : albedo(color(1, 1, 1)), refrac_index(refrac_index){};
     bool scatter(
         const ray& incoming, ray& outgoing, const intersection& hit, color& attenuation) const;
 };

--- a/src/raytrace/headers/world.h
+++ b/src/raytrace/headers/world.h
@@ -1,8 +1,8 @@
 #ifndef _RAYTERM_WORLD_H_
 #define _RAYTERM_WORLD_H_
 #include <memory>
-#include "raymath"
 #include "material.h"
+#include "raymath"
 
 #define MAXDEPTH 32
 
@@ -28,7 +28,6 @@ class World {
     color trace(ray r, intersection& record, int depth);
 };
 
-
 // WorldObject joins geometry (possibly more than one) to a colorize function.
 // This enables the use of materials, shading, and more.
 class WorldObject {
@@ -38,7 +37,8 @@ class WorldObject {
     World* world;
 
    public:
-    WorldObject(long id, Material* material, World* world, geometry* first_geometry) : id(id), material(material), world(world) {
+    WorldObject(long id, Material* material, World* world, geometry* first_geometry)
+        : id(id), material(material), world(world) {
         add_geometry(first_geometry);
     }
 

--- a/src/raytrace/test/raytracer_tests.cpp
+++ b/src/raytrace/test/raytracer_tests.cpp
@@ -1,14 +1,11 @@
 #include <gtest/gtest.h>
-#include "raytracer.h"
-#include <cstdio>
 #include <chrono>
+#include <cstdio>
+#include "raytracer.h"
 
-void progress_cb(float progress) {
-    printf("\b\b\b%02d%%", int(progress * 100));
-}
+void progress_cb(float progress) { printf("\b\b\b%02d%%", int(progress * 100)); }
 
 TEST(RaytracerTest, Success) {
-
     printf("00%");
     std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
 
@@ -18,7 +15,8 @@ TEST(RaytracerTest, Success) {
 
     printf("\b\b\b100% -- Render Complete!\n");
 
-    printf("Completed in %dms\n", std::chrono::duration_cast<std::chrono::milliseconds>(end - begin).count());
+    printf("Completed in %dms\n",
+        std::chrono::duration_cast<std::chrono::milliseconds>(end - begin).count());
 
     EXPECT_EQ(raytrace_ppm("test_image.ppm"), 0) << "Did not successfully generate a test image!";
 }

--- a/src/raytrace/test/raytracer_tests.cpp
+++ b/src/raytrace/test/raytracer_tests.cpp
@@ -6,14 +6,14 @@
 void progress_cb(float progress) { printf("\b\b\b%02d%%", int(progress * 100)); }
 
 TEST(RaytracerTest, Success) {
-    printf("00%");
+    printf("00%%");
     std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
 
     int status = raytrace_ppm("test_image.ppm", progress_cb);
 
     std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
 
-    printf("\b\b\b100% -- Render Complete!\n");
+    printf("\b\b\b100%% -- Render Complete!\n");
 
     printf("Completed in %dms\n",
         std::chrono::duration_cast<std::chrono::milliseconds>(end - begin).count());

--- a/src/raytrace/test/raytracer_tests.cpp
+++ b/src/raytrace/test/raytracer_tests.cpp
@@ -3,7 +3,11 @@
 #include <cstdio>
 #include "raytracer.h"
 
-void progress_cb(float progress) { printf("\b\b\b%02d%%", int(progress * 100)); }
+void progress_cb(float progress) {
+#ifndef NO_PROGRESS
+    printf("\b\b\b%02d%%", int(progress * 100));
+#endif
+}
 
 TEST(RaytracerTest, Success) {
     printf("00%%");

--- a/src/raytrace/test/raytracer_tests.cpp
+++ b/src/raytrace/test/raytracer_tests.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include "raytracer.h"
 #include <cstdio>
+#include <chrono>
 
 void progress_cb(float progress) {
     printf("\b\b\b%02d%%", int(progress * 100));
@@ -9,7 +10,15 @@ void progress_cb(float progress) {
 TEST(RaytracerTest, Success) {
 
     printf("00%");
+    std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
+
     int status = raytrace_ppm("test_image.ppm", progress_cb);
+
+    std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
+
     printf("\b\b\b100% -- Render Complete!\n");
+
+    printf("Completed in %dms\n", std::chrono::duration_cast<std::chrono::milliseconds>(end - begin).count());
+
     EXPECT_EQ(raytrace_ppm("test_image.ppm"), 0) << "Did not successfully generate a test image!";
 }

--- a/src/raytrace/test/world_tests.cpp
+++ b/src/raytrace/test/world_tests.cpp
@@ -4,9 +4,9 @@
 
 TEST(World, CanAddGeometrys) {
     World w;
-    Material* red = new Lambertian(color(1, 0, 0));
-    Material* green = new Lambertian(color(0, 1, 0));
-    Material* blue = new Lambertian(color(0, 0, 1));
+    Material* red     = new Lambertian(color(1, 0, 0));
+    Material* green   = new Lambertian(color(0, 1, 0));
+    Material* blue    = new Lambertian(color(0, 0, 1));
     geometry* sphere1 = new sphere(vector(0, 0, 0), 2);
     geometry* sphere2 = new sphere(vector(0, 0, 2), 4);
     geometry* sphere3 = new sphere(vector(0, 0, 0), 5);
@@ -17,9 +17,9 @@ TEST(World, CanAddGeometrys) {
 
 TEST(World, CanIntersectGeometrys) {
     World w;
-    Material* red = new Lambertian(color(1, 0, 0));
-    Material* green = new Lambertian(color(0, 1, 0));
-    Material* blue = new Lambertian(color(0, 0, 1));
+    Material* red     = new Lambertian(color(1, 0, 0));
+    Material* green   = new Lambertian(color(0, 1, 0));
+    Material* blue    = new Lambertian(color(0, 0, 1));
     geometry* sphere1 = new sphere(vector(0, 0, 0), 2);
     geometry* sphere2 = new sphere(vector(0, 0, 2), 4);
     geometry* sphere3 = new sphere(vector(0, 0, 0), 5);

--- a/test.sh
+++ b/test.sh
@@ -9,7 +9,7 @@ while [ $# -gt 0 ]; do
     case $1 in
         -r|--res|--resolution|--multi)
             if [ $# -gt 1 ]; then
-                FLAGS="$FLAGS -PRES_MULT=$2"
+                FLAGS="$FLAGS-PRES_MULT=$2 "
                 shift
             else
                 echo -e "\033[91mNo value specified after $1!'\033[0m"
@@ -17,7 +17,7 @@ while [ $# -gt 0 ]; do
         ;;
         -s|--samples)
             if [ $# -gt 1 ]; then
-                FLAGS="$FLAGS -PSAMPLES=$2"
+                FLAGS="$FLAGS-PSAMPLES=$2 "
                 shift
             else
                 echo -e "\033[91mNo integer value specified after $1!'\033[0m"
@@ -25,6 +25,9 @@ while [ $# -gt 0 ]; do
         ;;
         -o|--open)
             OPEN=true
+        ;;
+        -np|--no-progress)
+            FLAGS="$FLAGS-PNO_PROGRESS "
         ;;
         *)
             echo -e "\033[2;91mUnrecognized flag '$1!'\033[0m"

--- a/test.sh
+++ b/test.sh
@@ -1,15 +1,56 @@
 #!/bin/bash
 # Run raytraceTest only
 
-gradle installRaytraceTestReleaseGoogleTestExe
 
-if  [[ "$?" != "0" ]]; then
+# parse flags
+OUTPUT=false
+FLAGS=""
+while [ $# -gt 0 ]; do
+    case $1 in
+        -r|--res|--resolution|--multi)
+            if [ $# -gt 1 ]; then
+                FLAGS="$FLAGS -PRES_MULT=$2"
+                shift
+            else
+                echo -e "\033[91mNo value specified after $1!'\033[0m"
+            fi
+        ;;
+        -s|--samples)
+            if [ $# -gt 1 ]; then
+                FLAGS="$FLAGS -PSAMPLES=$2"
+                shift
+            else
+                echo -e "\033[91mNo integer value specified after $1!'\033[0m"
+            fi
+        ;;
+        -o|--open)
+            OPEN=true
+        ;;
+        *)
+            echo -e "\033[2;91mUnrecognized flag '$1!'\033[0m"
+    esac
+shift
+done
+
+COMPILED=1
+if [[ "$FLAGS" != "" ]]; then
+    gradle installRaytraceTestReleaseGoogleTestExe $FLAGS
+    COMPILED=$?
+    echo "Compiled with $FLAGS"
+    shift
+else
+    gradle installRaytraceTestReleaseGoogleTestExe
+    COMPILED=$?
+    echo "Compiled with default samples"
+fi
+
+if  [[ "$COMPILED" != "0" ]]; then
     exit;
 fi
 
 ./build/install/raytraceTest/release/raytraceTest --gtest_filter=RaytracerTest.Success
 
-if [[ "$1" = "-o" ]]; then
+if [[ "$OPEN" = "true" ]]; then
     exec feh --force-aliasing -Z test_image.ppm &
     disown
 fi


### PR DESCRIPTION
This branch generated this image:
![Image](https://raw.githubusercontent.com/Michionlion/compdoc/master/hq_768spp_glass_metal_mirror_lambert_materials.png).

It should also be noted that this branch has a bug or unintended feature where metals have a sort of halo. This is caused (and fixed) by changing -MIN_CONTACT for dropping to the secondary t value to MIN_CONTACT. The problem is that the positive version is needed for glass (where rays are sent internally, so a MIN_CONTACT needs to drop -0 to the second t).